### PR TITLE
Prevent skipping empty charges with events

### DIFF
--- a/src/event/EventAwareTrait.php
+++ b/src/event/EventAwareTrait.php
@@ -44,4 +44,9 @@ trait EventAwareTrait
 
         return $events;
     }
+
+    public function hasEvents(): bool
+    {
+        return !empty($this->events);
+    }
 }

--- a/src/tools/DbMergingAggregator.php
+++ b/src/tools/DbMergingAggregator.php
@@ -63,6 +63,11 @@ class DbMergingAggregator implements AggregatorInterface
     private function excludeLocalOnlyZeroBills(array $localBills, array $dbBills): array
     {
         foreach ($localBills as $i => $localBill) {
+            foreach ($localBill->getCharges() as $charge) {
+                if ($charge->hasEvents()) {
+                    continue 2;
+                }
+            }
             $isZeroSum = $localBill->getSum()->getAmount() === "0";
             if (!$isZeroSum) {
                 continue;


### PR DESCRIPTION
To allow handling of events in particular `LeasingWasFinished`