### PR TITLE
Remove unsupported PHP version tests

### DIFF
--- a/.github/workflows/behat-tests.yml
+++ b/.github/workflows/behat-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.1', '8.3']
+        php: ['8.3']
         coverage-driver: [pcov]
     name: PHP ${{ matrix.php }}
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the testing workflow to support only PHP version 8.3, simplifying the testing environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->