### PR TITLE
Modernize Bill with native PHP 8.3 type declarations

### DIFF
--- a/src/bill/Bill.php
+++ b/src/bill/Bill.php
@@ -28,47 +28,33 @@ use Money\Money;
  */
 class Bill implements BillInterface
 {
-    /** @var TypeInterface */
-    protected $type;
+    protected TypeInterface $type;
 
-    /** @var DateTimeImmutable */
-    protected $time;
+    protected DateTimeImmutable $time;
 
-    /** @var Money */
-    protected $sum;
+    protected Money $sum;
 
-    /** @var QuantityInterface */
-    protected $quantity;
+    protected QuantityInterface $quantity;
 
-    /** @var CustomerInterface */
-    protected $customer;
+    protected CustomerInterface $customer;
 
-    /** @var TargetInterface */
-    protected $target;
+    protected ?TargetInterface $target;
 
-    /** @var BillRequisite */
-    protected $requisite;
+    protected ?BillRequisite $requisite = null;
 
-    /** @var PlanInterface */
-    protected $plan;
+    protected ?PlanInterface $plan;
 
     /** @var ChargeInterface[] */
-    protected $charges = [];
+    protected array $charges = [];
 
-    /** @var BillState */
-    protected $state;
+    protected ?BillState $state;
 
-    /** @var string */
-    protected $comment;
+    protected string $comment = '';
 
-    /** @var UsageInterval */
-    protected $usageInterval;
+    protected UsageInterval $usageInterval;
 
-    /**
-     * @param int|string $id
-     */
     public function __construct(
-        protected $id,
+        protected int|string|null $id,
         TypeInterface $type,
         DateTimeImmutable $time,
         Money $sum,
@@ -109,7 +95,7 @@ class Bill implements BillInterface
 
     public function getUsageInterval(): UsageInterval
     {
-        if ($this->usageInterval === null) {
+        if (!isset($this->usageInterval)) {
             $this->initializeWholeMonthUsageInterval();
         }
 
@@ -121,22 +107,19 @@ class Bill implements BillInterface
         $this->setUsageInterval(UsageInterval::wholeMonth($this->time));
     }
 
-    public function calculatePrice()
+    public function calculatePrice(): Money
     {
         $quantity = $this->quantity->getQuantity();
 
         return $quantity ? $this->sum->divide(sprintf('%.14F', $quantity)) : $this->sum;
     }
 
-    /**
-     * @return int|string
-     */
-    public function getId()
+    public function getId(): int|string|null
     {
         return $this->id;
     }
 
-    public function setId($id)
+    public function setId(int|string $id): void
     {
         if ($this->id === $id) {
             return;
@@ -177,7 +160,7 @@ class Bill implements BillInterface
         return $this->quantity;
     }
 
-    public function setQuantity(QuantityInterface $quantity): BillInterface
+    public function setQuantity(QuantityInterface $quantity): static
     {
         $this->quantity = $quantity;
 
@@ -208,10 +191,10 @@ class Bill implements BillInterface
     }
 
     /**
-     * @param ChargeInterface[] $prices
-     * @throws \Exception
+     * @param ChargeInterface[] $charges
+     * @throws CannotReassignException
      */
-    public function setCharges(array $charges): self
+    public function setCharges(array $charges): static
     {
         if ($this->hasCharges()) {
             throw new CannotReassignException('bill charges');
@@ -236,12 +219,12 @@ class Bill implements BillInterface
         return $this->state === null ? null : $this->state->isFinished();
     }
 
-    public function getComment()
+    public function getComment(): string
     {
         return $this->comment;
     }
 
-    public function setComment(string $comment)
+    public function setComment(string $comment): void
     {
         $this->comment = $comment;
     }

--- a/src/bill/BillInterface.php
+++ b/src/bill/BillInterface.php
@@ -52,7 +52,7 @@ interface BillInterface extends EntityInterface
     /**
      * @return ChargeInterface[]
      */
-    public function getCharges();
+    public function getCharges(): array;
 
     public function getUsageInterval(): UsageInterval;
 


### PR DESCRIPTION
## Summary

- Replace all PHPDoc `@var` annotations on Bill properties with native PHP typed properties
- Add return types to methods that were missing them (`getId()`, `calculatePrice()`, `getComment()`, `setId()`, `setComment()`)
- Add `array` return type to `BillInterface::getCharges()` 
- Use union type `int|string|null` for `$id` constructor parameter
- Fix PHPDoc typo: `@param $prices` → `@param $charges` in `setCharges()`
- Fix `@throws \Exception` → `@throws CannotReassignException` (actual exception thrown)
- Use `static` instead of `self`/`BillInterface` for fluent setter return types

## Motivation

The project requires PHP 8.3+ (`composer.json`). Native type declarations improve:
- Static analysis (Psalm, PHPStan) accuracy
- IDE autocompletion and refactoring
- Runtime type safety — catch type errors at assignment, not at usage

## Test plan

- [ ] Verify existing PHPUnit tests pass
- [ ] Verify Behat tests pass
- [ ] Run Psalm static analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal code reliability through improved type safety declarations in the billing module, ensuring more robust data handling and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->