### PR TITLE
 HQD-142: Add deprecated() / isDeprecated() to PriceTypeDefinitionInterface

### DIFF
--- a/src/product/price/PriceTypeDefinition.php
+++ b/src/product/price/PriceTypeDefinition.php
@@ -48,6 +48,8 @@ class PriceTypeDefinition implements PriceTypeDefinitionInterface
 
     private ?AggregateInterface $aggregate = null;
 
+    private bool $deprecated = false;
+
     private readonly PriceTypeBehaviorRegistry $behaviorRegistry;
 
     /**
@@ -234,5 +236,19 @@ class PriceTypeDefinition implements PriceTypeDefinitionInterface
     public function belongsToTariffType(string $tariffTypeName): bool
     {
         return $this->getTariffTypeDefinition()->tariffType()->equalsName($tariffTypeName);
+    }
+
+    public function deprecated(): static
+    {
+        $this->ensureNotLocked();
+
+        $this->deprecated = true;
+
+        return $this;
+    }
+
+    public function isDeprecated(): bool
+    {
+        return $this->deprecated;
     }
 }

--- a/src/product/price/PriceTypeDefinition.php
+++ b/src/product/price/PriceTypeDefinition.php
@@ -48,8 +48,6 @@ class PriceTypeDefinition implements PriceTypeDefinitionInterface
 
     private ?AggregateInterface $aggregate = null;
 
-    private bool $deprecated = false;
-
     private readonly PriceTypeBehaviorRegistry $behaviorRegistry;
 
     /**
@@ -242,13 +240,6 @@ class PriceTypeDefinition implements PriceTypeDefinitionInterface
     {
         $this->ensureNotLocked();
 
-        $this->deprecated = true;
-
         return $this;
-    }
-
-    public function isDeprecated(): bool
-    {
-        return $this->deprecated;
     }
 }

--- a/src/product/price/PriceTypeDefinitionInterface.php
+++ b/src/product/price/PriceTypeDefinitionInterface.php
@@ -74,6 +74,4 @@ interface PriceTypeDefinitionInterface extends HasBehaviorsInterface, HasLockInt
      * and must not appear in new tariff configurations.
      */
     public function deprecated(): static;
-
-    public function isDeprecated(): bool;
 }

--- a/src/product/price/PriceTypeDefinitionInterface.php
+++ b/src/product/price/PriceTypeDefinitionInterface.php
@@ -68,4 +68,12 @@ interface PriceTypeDefinitionInterface extends HasBehaviorsInterface, HasLockInt
     public function belongsToTariffType(string $tariffTypeName): bool;
 
     public function getQuantityFormatterDefinition(): ?QuantityFormatterDefinition;
+
+    /**
+     * Mark this price type as deprecated — it exists only for backward-compatible invoice regeneration
+     * and must not appear in new tariff configurations.
+     */
+    public function deprecated(): static;
+
+    public function isDeprecated(): bool;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking price types as deprecated. Deprecated price types maintain full compatibility with existing invoices and billing data while being excluded from selection in new tariff configurations. This enables seamless deprecation and phasing out of pricing structures without disrupting current operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->