### PR TITLE
Add findOneById() to TargetRepositoryInterface

### DIFF
--- a/src/target/TargetRepositoryInterface.php
+++ b/src/target/TargetRepositoryInterface.php
@@ -24,5 +24,10 @@ interface TargetRepositoryInterface
      */
     public function findOne($specification);
 
+    /**
+     * @param int|string $id
+     */
+    public function findOneById($id): ?TargetInterface;
+
     public function save(TargetInterface $target): void;
 }


### PR DESCRIPTION
HQD-440: hiapi-legacy's Price\Module::_pricesSuggest() already called findOneById() on the DI-resolved TargetRepositoryInterface, relying on billing-mrdp's TargetRepository (the sole binding) implementing it beyond the interface. Declaring it on the interface fixes the resulting psalm UndefinedInterfaceMethod error without coupling the caller to a concrete class from a different package.


Claude-Session: https://claude.ai/code/session_014dZ7nxrR24gXhFgGFHaXXN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving a target by its identifier.
  - Identifiers can be provided as either integers or strings.
  - Returns the matching target when available, or no result when not found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->